### PR TITLE
Ft/logs auditing

### DIFF
--- a/app/dashboard/components/log-icon.tsx
+++ b/app/dashboard/components/log-icon.tsx
@@ -1,0 +1,15 @@
+import { MessageSquare, FileText, Brain, User } from "lucide-react";
+import React from "react";
+
+const LogIcon = ({ type }: { type: string }) => {
+  return (
+    <div>
+      {type === "feedback" && <MessageSquare className="w-4 h-4" />}
+      {type === "self-assessment" && <FileText className="w-4 h-4" />}
+      {type === "ai-score" && <Brain className="w-4 h-4" />}
+      {type === "login" && <User className="w-4 h-4" />}
+    </div>
+  );
+};
+
+export default LogIcon;

--- a/app/dashboard/components/recent-activity.tsx
+++ b/app/dashboard/components/recent-activity.tsx
@@ -13,7 +13,7 @@ export const RecentActivity = ({activities}:{activities: ActivityPayload[]}) => 
             <div className="p-6 space-y-4">
                 {
                     activities.map(activity => {
-                        const { id, type, title, timestamp,} = activity
+                        const { id, type, title, timestamp} = activity
                         return (
                         <div
                             key={id}

--- a/app/dashboard/components/recent-activity.tsx
+++ b/app/dashboard/components/recent-activity.tsx
@@ -1,31 +1,9 @@
+import { ActivityPayload } from "@/lib/types/activities";
 import clsx from "clsx";
-import { Activity, Brain, FileText, MessageSquare } from "lucide-react";
+import { Activity, } from "lucide-react";
+import LogIcon from "./log-icon";
 
-const activities = [
-    {
-        id: 1,
-        icon: MessageSquare,
-        type: 'feedback',
-        title: 'Lisa Thompson provided feedback for Michael Rodriguez',
-        timestamp: '13/02/2024, 12:15:00'
-    },
-    {
-        id: 2,
-        icon: FileText,
-        type: 'self-assessment',
-        title: 'Michael Rodriguez submitted a self-assessment',
-        timestamp: '13/02/2024, 12:15:00'
-    },
-    {
-        id: 3,
-        icon: Brain,
-        type: 'ai-score',
-        title: 'AI score updated for Jane Doe',
-        timestamp: '13/02/2024, 12:15:00'
-    }
-];
-
-export const RecentActivity = () => {
+export const RecentActivity = ({activities}:{activities: ActivityPayload[]}) => {
     return (
         <article className="bg-white dark:bg-primary/5 rounded-md border-[1px] shadow-xs">
             <div className="p-6 shadow-sm dark:border-b-[1px] flex items-center gap-2">
@@ -35,7 +13,7 @@ export const RecentActivity = () => {
             <div className="p-6 space-y-4">
                 {
                     activities.map(activity => {
-                        const { id, type, title, timestamp, icon: Icon} = activity
+                        const { id, type, title, timestamp,} = activity
                         return (
                         <div
                             key={id}
@@ -51,7 +29,7 @@ export const RecentActivity = () => {
                                     }
                                 )}
                             >
-                                <Icon className="w-4 h-4" />
+                                <LogIcon type={type} />
                             </div>
                             <div className="flex flex-col">
                                 <p className="text-sm text-foreground/80">{title}</p>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -38,6 +38,26 @@ const stats = [
         icon: ChartColumn,
     }
 ];
+const activities = [
+    {
+        id: "!",
+        type: 'feedback',
+        title: 'Lisa Thompson provided feedback for Michael Rodriguez',
+        timestamp: '13/02/2024, 12:15:00'
+    },
+    {
+        id: "2",
+        type: 'self-assessment',
+        title: 'Michael Rodriguez submitted a self-assessment',
+        timestamp: '13/02/2024, 12:15:00'
+    },
+    {
+        id: "3",
+        type: 'ai-score',
+        title: 'AI score updated for Jane Doe',
+        timestamp: '13/02/2024, 12:15:00'
+    }
+];
 
 export default function Dashboard() {
     return (
@@ -51,7 +71,7 @@ export default function Dashboard() {
                 }
             </section>
             <section className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <RecentActivity />
+                <RecentActivity activities={activities}/>
                 <AiInsights />
             </section>
         </main>

--- a/app/dashboard/security/components/sessions/sessions.tsx
+++ b/app/dashboard/security/components/sessions/sessions.tsx
@@ -4,10 +4,6 @@ import { getSessions } from "@/lib/api/session";
 import SessionActions from "./actions";
 import { Badge } from "@/components/ui/badge";
 import SessionFilters from "./session-filters";
-<<<<<<< HEAD
-import { Column } from "@/components/custom/app-table";
-=======
->>>>>>> c1a722f (fix(types): modifies the session component's data types)
 import { Session } from "@/lib/types/sessions";
 
 const SessionsTable = async () => {
@@ -35,11 +31,7 @@ const SessionsTable = async () => {
   );
 };
 
-<<<<<<< HEAD
 export const sessionColumns: Column<Session>[] = [
-=======
-export const sessionColumns:Column<Session>[] = [
->>>>>>> c1a722f (fix(types): modifies the session component's data types)
   { key: "user_name", label: "User" },
   { key: "device_info", label: "Device" },
   { key: "ip_address", label: "IP Address" },

--- a/app/dashboard/security/components/sessions/sessions.tsx
+++ b/app/dashboard/security/components/sessions/sessions.tsx
@@ -1,10 +1,13 @@
-import AppTable from "@/components/custom/app-table";
+import AppTable, { Column } from "@/components/custom/app-table";
 import ErrorDiv from "@/components/custom/ErrorDiv";
 import { getSessions } from "@/lib/api/session";
 import SessionActions from "./actions";
 import { Badge } from "@/components/ui/badge";
 import SessionFilters from "./session-filters";
+<<<<<<< HEAD
 import { Column } from "@/components/custom/app-table";
+=======
+>>>>>>> c1a722f (fix(types): modifies the session component's data types)
 import { Session } from "@/lib/types/sessions";
 
 const SessionsTable = async () => {
@@ -32,7 +35,11 @@ const SessionsTable = async () => {
   );
 };
 
+<<<<<<< HEAD
 export const sessionColumns: Column<Session>[] = [
+=======
+export const sessionColumns:Column<Session>[] = [
+>>>>>>> c1a722f (fix(types): modifies the session component's data types)
   { key: "user_name", label: "User" },
   { key: "device_info", label: "Device" },
   { key: "ip_address", label: "IP Address" },

--- a/lib/types/activities.ts
+++ b/lib/types/activities.ts
@@ -1,0 +1,6 @@
+export interface ActivityPayload {
+    id: string;
+    type: string;
+    title: string;
+    timestamp: string;
+}


### PR DESCRIPTION
# Refactors Activity Logs
## Overview
This pull request modifies and styled `RecentActivity` component to make it reusable acrross different pages on the dashboard such as the admin dashboard and the user dashboard

## Key Features
- Creates the reusable `LogIcon` that will decide which icon to render based on the type of the log or the activity
- Made `RecentActivity` component reusable and it accepts props passed to it for render
- adjusted the session component's types to avoid using `any` type as its not ideal

## Purpose
Improves the overall reusability of the component

## Changes Summary
- Created `LogIcon` for rendering icons based on the log type
- Made `RecentActivity` component reusab;e
- Changed `AppTable` component types